### PR TITLE
Audio player mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ DEVICE = 'pi'
 USE_GUI = False
 DISPLAY_FPS = False
 N_PIXELS = 144
-MIC_RATE = 48000
+AUDIO_RATE = 48000
 FPS = 50
 ```
 
@@ -274,7 +274,7 @@ The connections are:
 7. In [config.py](python/config.py):
   - Set `N_PIXELS` to the number of LEDs in your LED strip (must match `NUM_LEDS` in [ws2812_controller.ino](arduino/ws2812_controller/ws2812_controller.ino))
   - Set `UDP_IP` to the IP address of your ESP8266 (must match `ip` in [ws2812_controller.ino](arduino/ws2812_controller/ws2812_controller.ino))
-  - If needed, set `MIC_RATE` to your microphone sampling rate in Hz. Most of the time you will not need to change this.
+  - If needed, set `AUDIO_RATE` to your microphone sampling rate in Hz. Most of the time you will not need to change this.
 
 # Installation for Raspberry Pi
 If you encounter any problems running the visualization on a Raspberry Pi, please [open a new issue](https://github.com/scottlawsonbc/audio-reactive-led-strip/issues). Also, please consider opening an issue if you have any questions or suggestions for improving the installation process.

--- a/python/audio_player.py
+++ b/python/audio_player.py
@@ -1,0 +1,85 @@
+import time
+import numpy as np
+import pyaudio
+import config
+import wave
+import queue
+import os
+
+wave_file = None
+loopback_audio_stream = queue.Queue()
+audio_file_paths = []
+audio_file_index = 0
+
+
+def scan_audio_files():
+	for entry in os.scandir(config.AUDIO_FILE_SCAN_PATH):
+		if entry.is_file() and entry.path.endswith('.wav'):
+			audio_file_paths.append(entry.path)
+
+	# If only one file, add it twice so the list looping will still work
+	if len(audio_file_paths) == 1:
+		audio_file_paths.append(audio_file_paths[0])
+
+
+def need_more_data_callback(in_data, frame_count, time_info, status):
+	global wave_file
+	global audio_file_index
+	ret_status = pyaudio.paComplete
+
+	data = None
+	if wave_file:
+		data = wave_file.readframes(frame_count)
+		if len(data) < frame_count:
+			wave_file = None
+			# Loop to next audio file
+			audio_file_index = (audio_file_index + 1) % len(audio_file_paths)
+		else:
+			# Pass the data chunks back to visualization via queue
+			loopback_audio_stream.put(data)
+			# More data to come
+			ret_status = pyaudio.paContinue
+	return data, ret_status
+
+
+def start_stream(callback):
+	global wave_file
+
+	scan_audio_files()
+	p = pyaudio.PyAudio()
+
+	while True:
+		playing_audio_file_index = audio_file_index
+		audio_file_path = audio_file_paths[audio_file_index]
+		wave_file = wave.open(audio_file_path, 'rb')
+		assert (wave_file.getframerate() == config.AUDIO_RATE)
+
+		# Creates a Stream to which the wav file is written to.
+		# Setting output to "True" makes the sound be "played" rather than recorded
+		stream = p.open(format=p.get_format_from_width(wave_file.getsampwidth()),
+						channels=wave_file.getnchannels(),
+						rate=wave_file.getframerate(),
+						output=True,
+						stream_callback=need_more_data_callback)
+
+		# Visualize the latest played samples until file changes
+		while playing_audio_file_index == audio_file_index:
+			# Clear the queue to wait for newest samples
+			while not loopback_audio_stream.empty():
+				loopback_audio_stream.get(block=False)
+			try:
+				data = loopback_audio_stream.get(timeout=1)
+			except queue.Empty:
+				break
+			y = np.fromstring(data, dtype=np.int16)
+			y = y.astype(np.float32)
+			# Small delay before visualization to sync it better
+			time.sleep(0.01)
+			callback(y)
+
+		# Close the stream
+		stream.stop_stream()
+		stream.close()
+
+	p.terminate()
+

--- a/python/config.py
+++ b/python/config.py
@@ -46,6 +46,9 @@ if DEVICE == 'blinkstick':
 USE_GUI = False
 """Whether or not to display a PyQtGraph GUI plot of visualization"""
 
+AUDIO_PLAYER_MODE = False
+"""False = Listen to microphone | True = Play music from file(s)"""
+
 DISPLAY_FPS = True
 """Whether to display the FPS when running (can reduce performance)"""
 
@@ -55,11 +58,26 @@ N_PIXELS = 144
 GAMMA_TABLE_PATH = os.path.join(os.path.dirname(__file__), 'gamma_table.npy')
 """Location of the gamma correction table"""
 
-MIC_RATE = 48000
-"""Sampling frequency of the microphone in Hz"""
+AUDIO_RATE = 48000
+"""Sampling frequency of the microphone or audio file in Hz"""
 
-FPS = 50
-"""Desired refresh rate of the visualization (frames per second)
+AUDIO_FILE_SCAN_PATH = '/home/pi'
+"""Path to scan audio files from (for player mode only)"""
+
+if AUDIO_PLAYER_MODE:
+    AUDIO_FRAME_SIZE = 1024
+    """How many audio samples are processed as a frame, defined by pyaudio/portaudio stream callback"""
+
+    FPS = int(AUDIO_RATE / AUDIO_FRAME_SIZE)
+    """Target FPS is automatically calculated"""
+else:
+    FPS = 50
+    """Target FPS, read more info below"""
+
+    AUDIO_FRAME_SIZE = int(AUDIO_RATE / FPS)
+    """Audio frame size is automatically calculated"""
+
+"""FPS = Desired refresh rate of the visualization (frames per second)
 
 FPS indicates the desired refresh rate, or frames-per-second, of the audio
 visualization. The actual refresh rate may be lower if the computer cannot keep

--- a/python/dsp.py
+++ b/python/dsp.py
@@ -28,25 +28,25 @@ class ExpFilter:
 def rfft(data, window=None):
     window = 1.0 if window is None else window(len(data))
     ys = np.abs(np.fft.rfft(data * window))
-    xs = np.fft.rfftfreq(len(data), 1.0 / config.MIC_RATE)
+    xs = np.fft.rfftfreq(len(data), 1.0 / config.AUDIO_RATE)
     return xs, ys
 
 
 def fft(data, window=None):
     window = 1.0 if window is None else window(len(data))
     ys = np.fft.fft(data * window)
-    xs = np.fft.fftfreq(len(data), 1.0 / config.MIC_RATE)
+    xs = np.fft.fftfreq(len(data), 1.0 / config.AUDIO_RATE)
     return xs, ys
 
 
 def create_mel_bank():
     global samples, mel_y, mel_x
-    samples = int(config.MIC_RATE * config.N_ROLLING_HISTORY / (2.0 * config.FPS))
+    samples = int(config.AUDIO_FRAME_SIZE * config.N_ROLLING_HISTORY / 2.0)
     mel_y, (_, mel_x) = melbank.compute_melmat(num_mel_bands=config.N_FFT_BINS,
                                                freq_min=config.MIN_FREQUENCY,
                                                freq_max=config.MAX_FREQUENCY,
                                                num_fft_bands=samples,
-                                               sample_rate=config.MIC_RATE)
+                                               sample_rate=config.AUDIO_RATE)
 samples = None
 mel_y = None
 mel_x = None

--- a/python/microphone.py
+++ b/python/microphone.py
@@ -6,10 +6,10 @@ import config
 
 def start_stream(callback):
     p = pyaudio.PyAudio()
-    frames_per_buffer = int(config.MIC_RATE / config.FPS)
+    frames_per_buffer = config.AUDIO_FRAME_SIZE
     stream = p.open(format=pyaudio.paInt16,
                     channels=1,
-                    rate=config.MIC_RATE,
+                    rate=config.AUDIO_RATE,
                     input=True,
                     frames_per_buffer=frames_per_buffer)
     overflows = 0


### PR DESCRIPTION
Tested on Raspberry 3. Mic mode not tested after the changes.

Self-plays wav files and does not need microphone or any special pulseaudio configuration. Mono files supported only for now.

To run this as a normal user and not root (to access pulseaudio easily), do the following:
```
sudo chmod a+rw /dev/mem
sudo setcap 'cap_sys_rawio+eip' /usr/bin/python3.7
```
!!! This does not improve your security as it practically grants root for all users !!!