### PR TITLE
Adding functionality for using WS2801 LED Controller

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -38,6 +38,10 @@ if DEVICE == 'pi':
     """Set True if using an inverting logic level converter"""
     SOFTWARE_GAMMA_CORRECTION = True
     """Set to True because Raspberry Pi doesn't use hardware dithering"""
+    LED_CONTROLLER = 'ws281x'
+    """There are different types of led controllers. Default is ws281x.
+    Another option is WS2801.
+    """
 
 if DEVICE == 'blinkstick':
     SOFTWARE_GAMMA_CORRECTION = True

--- a/python/install/setup.py
+++ b/python/install/setup.py
@@ -10,5 +10,5 @@ setup(
     download_url="https://github.com/naztronaut/dancyPi-audio-reactive-led",
     description="Audio Reactive Raspberry Pi with WS2812b LEDs.",
     license="MIT",
-    install_requires=['numpy', 'pyaudio', 'pyqtgraph', 'scipy==1.4.1', 'rpi_ws281x']
+    install_requires=['numpy', 'pyaudio', 'pyqtgraph', 'scipy==1.4.1', 'rpi_ws281x', 'adafruit-ws2801']
 )


### PR DESCRIPTION
I've added some lines for WS2801 Led Controller Strips. By changing the config file, there is an option for the LED_CONTROLLER type. Basically there are changes in three of the files - config.py, setup.py, led.py. 
Config - adding LED_CONTROLLER variable
setup - adding the needed python library
led.py - adding different calls for WS2801

There shouldn't be regression problems, but currently I have only Pi and WS2801, so I've test it only on this setup. 